### PR TITLE
Patched for 1.5 Local Multiplayer

### DIFF
--- a/TimeMultiplier/manifest.json
+++ b/TimeMultiplier/manifest.json
@@ -1,10 +1,10 @@
 ﻿{
-  "Name": "TimeMultiplier",
-  "Author": "DefenTheNation",
-  "Version": "1.3",
-  "UniqueID": "DefenTheNation.TimeMultiplier",
-  "Description": "Adds a multiplier to the time counter to speed up or slow down the time progression. Recommended values are between 0.5 and 1.5.",
-  "EntryDll": "TimeMultiplier.dll",
-  "MinimumApiVersion": "3.1.0",
-  "UpdateKeys": [ "Nexus: 2262"  ]
+    "Name": "TimeMultiplier",
+    "Author": "DefenTheNation",
+    "Version": "1.3.1-unofficial.1-diocloid",
+    "UniqueID": "DefenTheNation.TimeMultiplier",
+    "Description": "Adds a multiplier to the time counter to speed up or slow down the time progression. Recommended values are between 0.5 and 1.5.",
+    "EntryDll": "TimeMultiplier.dll",
+    "MinimumApiVersion": "3.1.0",
+    "UpdateKeys": [ "Nexus: 2262" ]
 }


### PR DESCRIPTION
This patches 1.5 for Local Multiplayer. Fixes #2 
On joining a local multiplayer game, the SaveLoaded event is fired. The config is loaded but SaveFolderName is incomplete. Therefore the default values are applied. In local multiplayer the config values are shared, and the "host" continues with these default values. 
Fixed by only loading the config if Context.IsMainPlayer is true.
